### PR TITLE
WIP: Add support for round-robin load balancing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # Palmetto RMQ
 
-This module uses rabbitMQ as the pub/sub messaging component for palmetto flow applications
+This module uses rabbitMQ as the pub/sub messaging component for palmetto flow applications and also supports
+
+The default behavior works well if you want to have several subscribers that receive all messages.
+
+Optional behavior is to utilize the `roundRobin` option to distribute the message to the subscribers in a round-robin fashion.
+
+In either configuration you can optionally provide a `publishOnly` option. The returned instance will not receive any messages.
+
 
 [![Build Status](https://travis-ci.org/twilson63/palmetto-rmq.svg?branch=master)](https://travis-ci.org/twilson63/palmetto-rmq)
 
@@ -65,3 +72,100 @@ io.on('widget.all.request', function (event) {
 ```
 
 The service listens to the `widget.all.request` svc then uses the `from` node to publish the response to.
+
+------------------
+
+### Fetching response from scaled service
+
+#### Requesting from a scaled load-balanced service instance
+
+``` js
+//requestor-service.js
+
+var requestorIo = require('@twilson63/palmetto-rmq')({
+  endpoint: 'amqp://guest:guest@localhost:5672',
+  app: '<requestorServiceName>',
+  vhost: '<optional>'
+})
+
+var handlerIo = require('@twilson63/palmetto-rmq')({
+  endpoint: 'amqp://guest:guest@localhost:5672',
+  app: '<handlerServiceName>',
+  vhost: '<optional>',
+  roundRobin: true,
+  publishOnly: true // only the 'handlerService' will listen for messages
+})                  // this instance shouldn't participate in `roundRobin` consumption
+
+
+var uuid = uuid.v4()
+
+//setup response msg handler
+requestorIo.on(uuid, function (event) {
+  console.log(event.object)
+})
+
+//send request msg
+handlerIo.emit('send', {
+  to: 'widget.all.request',
+  from: uuid,
+  subject: 'widget',
+  verb: 'all',
+  type: 'request',
+  object: {}
+})
+```
+
+#### Receiving response from scaled load-balanced service
+
+``` js
+//handler-service.js
+
+var inboundIo = require('@twilson63/palmetto-rmq')({
+  endpoint: 'amqp://guest:guest@localhost:5672',
+  app: '<handlerServiceName>',
+  vhost: '<optional>',
+  roundRobin: true,   // all instances of 'handlerService' will get 'roundRobin' msg distribution
+  publishOnly: false  // and obviously listen for those msgs
+})
+
+var requestorIo = require('@twilson63/palmetto-rmq')({
+  endpoint: 'amqp://guest:guest@localhost:5672',
+  app: '<requestorServiceName>',
+  vhost: '<optional>'
+})
+
+
+//handle request messages
+inboundIo.on(uuid, function (event) {
+
+  doSomething(event.object)
+    .then(resultObject => {
+
+      requestorIo.emit('send', {
+        to: event.from,
+        from: event.to,
+        subject: event.subject + '-response',
+        verb: event.verb + '-response',
+        type: 'response',
+        object: resultObject
+      })
+
+    })
+    .catch(error => {
+
+      requestorIo.emit('send', {
+        to: event.from,
+        from: event.to,
+        subject: event.subject + '-error',
+        verb: event.verb + '-error',
+        type: 'response',
+        object: error
+      })
+
+    })
+})
+
+
+```
+
+

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ handlerIo.emit('send', {
 #### Handling request in scaled load-balanced service
 ``` js
 //handler-service.js
+//multiple instances of this service running
 
 var inboundIo = require('@twilson63/palmetto-rmq')({
   endpoint: 'amqp://guest:guest@localhost:5672',

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ The service listens to the `widget.all.request` svc then uses the `from` node to
 ### Fetching response from scaled service
 
 #### Requesting from a scaled load-balanced service instance
-
 ``` js
 //requestor-service.js
 
@@ -115,8 +114,7 @@ handlerIo.emit('send', {
 })
 ```
 
-#### Receiving response from scaled load-balanced service
-
+#### Handling request in scaled load-balanced service
 ``` js
 //handler-service.js
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Palmetto RMQ
 
-This module uses rabbitMQ as the pub/sub messaging component for palmetto flow applications and also supports
+This module uses rabbitMQ as the pub/sub messaging component for palmetto flow applications.
 
 The default behavior works well if you want to have several subscribers that receive all messages.
 

--- a/index.js
+++ b/index.js
@@ -19,6 +19,9 @@ module.exports = function (config) {
   }
 
   ee.on('send', function (event) {
+    console.log('config.listen: ' + config.listen);
+    console.log('config.app: ' + config.app);
+    console.log('event: ' + event);
     bus.publish(config.app, event)
   })
   return ee

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function (config) {
     console.log('config.listen: ' + config.listen);
     console.log('config.app: ' + config.app);
     console.log('event: ' + event);
-    bus.publish(config.app, event)
+    config.listen ? bus.send(config.app, event) : bus.publish(config.app, event);
   })
   return ee
 }

--- a/index.js
+++ b/index.js
@@ -11,17 +11,19 @@ module.exports = function (config) {
     vhost: config.vhost || null
   })
 
-  config.listen ? bus.listen(config.app, notify) : bus.subscribe(config.app, notify)
+  if (config.consumer) {
+    config.roundRobin ? bus.listen(config.app, notify) : bus.subscribe(config.app, notify)
+  }
 
   function notify (event) {
     if (event.to) ee.emit(event.to, event)
   }
 
   ee.on('send', function (event) {
-    console.log('config.listen: ' + config.listen);
+    console.log('config.roundRobin: ' + config.listen);
     console.log('config.app: ' + config.app);
     console.log('event: ' + event);
-    config.listen ? bus.send(config.app, event) : bus.publish(config.app, event);
+    config.roundRobin ? bus.send(config.app, event) : bus.publish(config.app, event);
   })
   return ee
 }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = function (config) {
-  const servicebus = require('servicebus')
-  const EventEmitter = require('events').EventEmitter
-  const ee = new EventEmitter()
+  var servicebus = require('servicebus')
+  var EventEmitter = require('events').EventEmitter
+  var ee = new EventEmitter()
   // validate config
   if (!config.endpoint) throw new Error('endpoint required!')
   if (!config.app) throw new Error('app required!')
@@ -11,8 +11,8 @@ module.exports = function (config) {
     vhost: config.vhost || null
   })
 
-  if (config.consumer) {
-    config.roundRobin ? bus.listen(config.app, notify) : bus.subscribe(config.app, notify)
+  if (!config.publishOnly) {
+    config.roundRobin ? bus.listen(config.app, notify) : bus.subscribe(config.app, notify);
   }
 
   function notify (event) {
@@ -20,8 +20,9 @@ module.exports = function (config) {
   }
 
   ee.on('send', function (event) {
-    console.log('config.roundRobin: ' + config.listen);
     console.log('config.app: ' + config.app);
+    console.log('config.publishOnly: ' + !!config.publishOnly);
+    console.log('config.roundRobin: ' + !!config.roundRobin);
     console.log('event: ' + event);
     config.roundRobin ? bus.send(config.app, event) : bus.publish(config.app, event);
   })

--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
+var servicebus = require('servicebus')
+var EventEmitter = require('events').EventEmitter
+
 module.exports = function (config) {
-  var servicebus = require('servicebus')
-  var EventEmitter = require('events').EventEmitter
+
   var ee = new EventEmitter()
+
   // validate config
   if (!config.endpoint) throw new Error('endpoint required!')
   if (!config.app) throw new Error('app required!')

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
-var EventEmitter = require('events').EventEmitter
-var ee = new EventEmitter()
-var servicebus = require('servicebus')
-
 module.exports = function (config) {
+  const servicebus = require('servicebus')
+  const EventEmitter = require('events').EventEmitter
+  const ee = new EventEmitter()
   // validate config
   if (!config.endpoint) throw new Error('endpoint required!')
   if (!config.app) throw new Error('app required!')

--- a/index.js
+++ b/index.js
@@ -20,10 +20,6 @@ module.exports = function (config) {
   }
 
   ee.on('send', function (event) {
-    console.log('config.app: ' + config.app);
-    console.log('config.publishOnly: ' + !!config.publishOnly);
-    console.log('config.roundRobin: ' + !!config.roundRobin);
-    console.log('event: ' + event);
     config.roundRobin ? bus.send(config.app, event) : bus.publish(config.app, event);
   })
   return ee

--- a/index.js
+++ b/index.js
@@ -4,15 +4,15 @@ var servicebus = require('servicebus')
 
 module.exports = function (config) {
   // validate config
-  if (!config.endpoint) throw new Error('endpoint required!') 
+  if (!config.endpoint) throw new Error('endpoint required!')
   if (!config.app) throw new Error('app required!')
 
   var bus = servicebus.bus({
     url: config.endpoint,
     vhost: config.vhost || null
   })
-  
-  bus.subscribe(config.app, notify)
+
+  config.listen ? bus.listen(config.app, notify) : bus.subscribe(config.app, notify)
 
   function notify (event) {
     if (event.to) ee.emit(event.to, event)

--- a/test/listen_test.js
+++ b/test/listen_test.js
@@ -1,0 +1,30 @@
+var test = require('tap').test
+var rewire = require('rewire')
+var palmetto = rewire('../')
+
+test('listen', function (t) {
+  palmetto.__set__('servicebus', {
+    bus: function () {
+      return {
+        listen: function(n, fn) {
+          setTimeout(function () {
+            fn({ to: 'foo.bar', from: 'beepboop' })
+          }, 50)
+        },
+        send: function () {}
+      }
+    }
+  })
+
+  var ee = palmetto({
+    endpoint: 'amqp://guest:guest@localhost:5672',
+    app: 'foo',
+    roundRobin: true
+  })
+
+  ee.on('foo.bar', function (event) {
+    t.equals(event.to, 'foo.bar')
+    t.equals(event.from, 'beepboop')
+    t.end()
+  })
+})

--- a/test/send_test.js
+++ b/test/send_test.js
@@ -1,0 +1,26 @@
+var test = require('tap').test
+var rewire = require('rewire')
+var palmetto = rewire('../')
+
+test('send', function (t) {
+  palmetto.__set__('servicebus', {
+    bus: function () {
+      return {
+        listen: function() {},
+        send: function (n, e) {
+          t.equals(n, 'foo', 'should equal app name')
+          t.deepEquals(e, { to: 'widget.request.create', name: 'foobar'}, 'should equal object')
+        }
+      }
+    }
+  })
+
+  var ee = palmetto({
+    endpoint: 'amqp://guest:guest@localhost:5672',
+    app: 'foo',
+    roundRobin: true
+  })
+
+  ee.emit('send', { to: 'widget.request.create', name: 'foobar'})
+  t.end()
+})


### PR DESCRIPTION
*Opened for discussion:*
we can chat about the motivations for this PR
I've added the ability to utilize `servicebus`'s listen/round-robin support.
_we'll probably want to bump version if we merge these changes in_

new config options (not the best names):
* `roundRobin`
  * defaults to false, which falls back to pub/sub
  * If truthy, sets up a single queue with multiple round robin consumers. (competing consumer model)
  * can `send` to this queue.
    * vs pub/sub `publish`
* ~`consumer`~ `publishOnly`
  * ~defaults to not consuming (_might want to flip this so it defaults to previous functionality_)~
  * defaults to false, which allows instance to consume, as well as publish
    * if a consumer to roundRobin queue
      * will receive messages distributed in round-robin fashion between other listeners
    * if a consumer to pub/sub (default) queue
      * will receive all messages routed to all queues with same topic
 
