### PR TITLE
Add support for auto reconnection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/*

--- a/index.js
+++ b/index.js
@@ -21,8 +21,7 @@ function establishConnection(config, ee) {
   });
 
   bus.on('error', (err) => {
-    console.error('Unrecoverable servicebus error', err.stack);
-    process.exit(1);
+    ee.emit('error', err);
   });
 
   ee.removeAllListeners();
@@ -41,8 +40,8 @@ function establishConnection(config, ee) {
     }
   }
 
-  // Attach listeners to reconnect on closed connections/channels
-  if (config.reconnect) {
+  // Attach listeners to reconnect on closed connections/channels (true by default)
+  if (config.reconnect !== false) {
     bus.on('connection_close', () => {
       bus = establishConnection(config, ee);
     });

--- a/index.js
+++ b/index.js
@@ -9,21 +9,44 @@ module.exports = function (config) {
   if (!config.endpoint) throw new Error('endpoint required!')
   if (!config.app) throw new Error('app required!')
 
+  establishConnection(config, ee);
+
+  return ee
+}
+
+function establishConnection(config, ee) {
   var bus = servicebus.bus({
     url: config.endpoint,
     vhost: config.vhost || null
-  })
+  });
 
-  if (!config.publishOnly) {
-    config.roundRobin ? bus.listen(config.app, notify) : bus.subscribe(config.app, notify);
-  }
+  bus.on('error', (err) => {
+    console.error('Unrecoverable servicebus error', err.stack);
+    process.exit(1);
+  });
 
-  function notify (event) {
-    if (event.to) ee.emit(event.to, event)
-  }
-
+  ee.removeAllListeners();
   ee.on('send', function (event) {
     config.roundRobin ? bus.send(config.app, event) : bus.publish(config.app, event);
   })
-  return ee
+
+  if (!config.publishOnly) {
+    function notify (event) {
+      if (event.to) ee.emit(event.to, event)
+    }
+    if (config.roundRobin) {
+      bus.listen(config.app, notify);
+    } else {
+      bus.subscribe(config.app, notify);
+    }
+  }
+
+  // Attach listeners to reconnect on closed connections/channels
+  if (config.reconnect) {
+    bus.on('connection_close', () => {
+      bus = establishConnection(config, ee);
+    });
+  }
+  return bus;
 }
+

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function establishConnection(config, ee) {
     }
   }
 
-  // Attach listeners to reconnect on closed connections/channels (true by default)
+  // Automatically reconnect on closed connections (true by default)
   if (config.reconnect !== false) {
     bus.on('connection_close', () => {
       bus = establishConnection(config, ee);

--- a/index.js
+++ b/index.js
@@ -24,7 +24,8 @@ function establishConnection(config, ee) {
     ee.emit('error', err);
   });
 
-  ee.removeAllListeners();
+  // If this is a reconnection, the old listener is being replaced
+  ee.removeAllListeners(['send']);
   ee.on('send', function (event) {
     config.roundRobin ? bus.send(config.app, event) : bus.publish(config.app, event);
   })

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "tap": "^1.2.0"
   },
   "dependencies": {
-    "servicebus": "^1.0.15"
+    "servicebus": "https://github.com/ryanvm/servicebus.git#feature/expose-addtional-channel-conn-events"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twilson63/palmetto-rmq",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/test/listen_test.js
+++ b/test/listen_test.js
@@ -11,7 +11,8 @@ test('listen', function (t) {
             fn({ to: 'foo.bar', from: 'beepboop' })
           }, 50)
         },
-        send: function () {}
+        send: function () {},
+        on: function() {}
       }
     }
   })

--- a/test/publish_test.js
+++ b/test/publish_test.js
@@ -11,7 +11,8 @@ test('publish', function (t) {
           t.equals(n, 'foo', 'should equal app name')
           t.deepEquals(e, { to: 'widget.request.create', name: 'foobar'}, 'should equal object')
           
-        }
+        },
+        on: function() {}
       }
     }
   })

--- a/test/send_test.js
+++ b/test/send_test.js
@@ -10,7 +10,8 @@ test('send', function (t) {
         send: function (n, e) {
           t.equals(n, 'foo', 'should equal app name')
           t.deepEquals(e, { to: 'widget.request.create', name: 'foobar'}, 'should equal object')
-        }
+        },
+        on: function() {}
       }
     }
   })

--- a/test/subscribe_test.js
+++ b/test/subscribe_test.js
@@ -11,7 +11,8 @@ test('subscribe', function (t) {
             fn({ to: 'foo.bar', from: 'beepboop' })
           }, 50)
         },
-        publish: function () {}
+        publish: function () {},
+        on: function() {}
       }
     }
   })


### PR DESCRIPTION
This PR adds the ability to reestablish the queue connection if it receives a "connection closed" event. These can happen if RabbitMQ forcefully closes the connection or if the heartbeats time out due to networking issues.

There's also a minor feature addition of passing through error events from `servicebus`. Those can be handy.

BIG CAUTIONARY NOTE: This unfortunately relies on servicebus relaying the connection and channel close events from amqplib (which currently it does not). I have a pull request outstanding with the servicebus project to fix that, but until that PR is integrated, this PR requires my own fork of servicebus.
 