### PR TITLE
Depend on official upstream

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function establishConnection(config, ee) {
 
   // Automatically reconnect on closed connections (true by default)
   if (config.reconnect !== false) {
-    bus.on('connection_close', () => {
+    bus.on('connection.close', () => {
       bus = establishConnection(config, ee);
     });
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "tap": "^1.2.0"
   },
   "dependencies": {
-    "servicebus": "https://github.com/ryanvm/servicebus.git#feature/expose-addtional-channel-conn-events"
+    "servicebus": "^2.0.8"
   }
 }


### PR DESCRIPTION
Modify the package.json to depend on the official upstream now that it's propagating the necessary events.

Note: The upstream maintainer decided to use dot notation for the event name, so this PR also includes an accompanying change for that.