### PR TITLE
Feature: Attempt reconnection if ECONNREFUSED

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ function establishConnection(config, ee) {
 
   bus.on('error', (err) => {
     if ((err.code === 'ECONNREFUSED' || err.errno === 'ECONNREFUSED') && config._attempts <= 10) {
+      // Only happens if the Rabbit host is up, but the service not responsive (at startup)
       var retryInterval = Number(config.retryInterval) || 2000;
       debug('ECONNREFUSED (' + config.endpoint + ' / ' + config.app + '). Reconnection attempt #' + config._attempts + ' in ' + retryInterval + ' ms');
       setTimeout(() => { establishConnection(config, ee); }, retryInterval);

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function establishConnection(config, ee) {
   bus.on('error', (err) => {
     if ((err.code === 'ECONNREFUSED' || err.errno === 'ECONNREFUSED') && config._attempts <= 10) {
       var retryInterval = Number(config.retryInterval) || 2000;
-      debug('ECONNREFUSED (' + config.endpoint + ' / ' + config.app + '). Reconnection attempt #' + config._attempts + ' in ' + retryInterval + ' milliseconds');
+      debug('ECONNREFUSED (' + config.endpoint + ' / ' + config.app + '). Reconnection attempt #' + config._attempts + ' in ' + retryInterval + ' ms');
       setTimeout(() => { establishConnection(config, ee); }, retryInterval);
     } else {
       ee.emit('error', err);

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function establishConnection(config, ee) {
 
   bus.on('error', (err) => {
     if ((err.code === 'ECONNREFUSED' || err.errno === 'ECONNREFUSED') && config._attempts <= 10) {
-      let retryInterval = Number(config.retryInterval) || 2000;
+      var retryInterval = Number(config.retryInterval) || 2000;
       debug('ECONNREFUSED (' + config.endpoint + ' / ' + config.app + '). Reconnection attempt #' + config._attempts + ' in ' + retryInterval + ' milliseconds');
       setTimeout(() => { establishConnection(config, ee); }, retryInterval);
     } else {

--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
 var servicebus = require('servicebus')
+var debug = require('debug')('palmetto-rmq')
 var EventEmitter = require('events').EventEmitter
 
 module.exports = function (config) {
-
   var ee = new EventEmitter()
+
+  config._attempts = 0;
 
   // validate config
   if (!config.endpoint) throw new Error('endpoint required!')
@@ -15,13 +17,21 @@ module.exports = function (config) {
 }
 
 function establishConnection(config, ee) {
+  config._attempts++;
+
   var bus = servicebus.bus({
     url: config.endpoint,
     vhost: config.vhost || null
   });
 
   bus.on('error', (err) => {
-    ee.emit('error', err);
+    if ((err.code === 'ECONNREFUSED' || err.errno === 'ECONNREFUSED') && config._attempts <= 10) {
+      let retryInterval = Number(config.retryInterval) || 2000;
+      debug('ECONNREFUSED (' + config.endpoint + ' / ' + config.app + '). Reconnection attempt #' + config._attempts + ' in ' + retryInterval + ' milliseconds');
+      setTimeout(() => { establishConnection(config, ee); }, retryInterval);
+    } else {
+      ee.emit('error', err);
+    }
   });
 
   // If this is a reconnection, the old listener is being replaced

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "tap": "^1.2.0"
   },
   "dependencies": {
-    "servicebus": "^2.0.8"
+    "servicebus": "^2.0.8",
+    "debug": "^2.2.0"
   }
 }


### PR DESCRIPTION
This merge request responds to the `ECONNREFUSED` error. This will typically occur at startup when attempting to connect and the RabbitMQ host is up, but the service is not yet accepting connections.
